### PR TITLE
Ensure HSE crystal oscillator operation on F030

### DIFF
--- a/examples/py32f030/src/bin/rcc_hse.rs
+++ b/examples/py32f030/src/bin/rcc_hse.rs
@@ -1,0 +1,39 @@
+#![no_std]
+#![no_main]
+#![feature(impl_trait_in_assoc_type)]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use py32_hal::gpio::{Level, Output, Speed};
+use py32_hal::rcc::{Hse, HseMode, Sysclk};
+use py32_hal::time::mhz;
+use {defmt_rtt as _, panic_halt as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut cfg: py32_hal::Config = Default::default();
+    cfg.rcc.hse = Some(Hse {
+        freq: mhz(24),
+        mode: HseMode::Oscillator,
+    });
+    cfg.rcc.sys = Sysclk::HSE;
+    let p = py32_hal::init(cfg);
+
+    info!("Hello World!");
+
+    let mut led = Output::new(p.PA6, Level::High, Speed::Low);
+
+    loop {
+        info!("high");
+        led.set_high();
+        // Note that the delay implementation assumes two cycles for a loop
+        // consisting of a SUBS and BNE instruction, but the Cortex-M0+ uses
+        // 3 cycles. The following value should give a flashing frequency of
+        // about 1Hz.
+        cortex_m::asm::delay(8_000_000);
+
+        info!("low");
+        led.set_low();
+        cortex_m::asm::delay(8_000_000);
+    }
+}

--- a/src/rcc/f0.rs
+++ b/src/rcc/f0.rs
@@ -1,6 +1,8 @@
 // use crate::pac::flash::vals::Latency;
 use crate::pac::rcc::vals::Pllsrc;
 // pub use crate::pac::rcc::vals::Prediv as PllPreDiv;
+#[cfg(rcc_f030)]
+use crate::pac::rcc::vals::HseFreq;
 #[cfg(rcc_f072)]
 pub use crate::pac::rcc::vals::Pllmul as PllMul;
 pub use crate::pac::rcc::vals::{
@@ -138,6 +140,14 @@ pub(crate) unsafe fn init(config: Config) {
                 HseMode::Oscillator => assert!(max::HSE_OSC.contains(&hse.freq)),
             }
 
+            #[cfg(rcc_f030)]
+            RCC.ecscr().modify(|w| {
+                w.set_hse_freq(match hse.freq.0 {
+                    ..=8_000_000 => HseFreq::RANGE1,
+                    ..=16_000_000 => HseFreq::RANGE2,
+                    _ => HseFreq::RANGE3,
+                })
+            });
             RCC.cr()
                 .modify(|w| w.set_hsebyp(hse.mode != HseMode::Oscillator));
             RCC.cr().modify(|w| w.set_hseon(true));


### PR DESCRIPTION
On the PY32F030, the RCC_ECSCR register has a field HSE_FREQ that needs to be set for the crystal oscillator to operate. That field is not present on the F072.

Being new to Rust, I'm not sure this is the right way to do it. I would like to use the `Hertz` type, but that doesn't seem to be possible in a range pattern. Feel free to suggest improvements or modify it yourself.