### PR TITLE
Add UID driver & hardware validated PY32F030 example

### DIFF
--- a/examples/py32f030/src/bin/uid.rs
+++ b/examples/py32f030/src/bin/uid.rs
@@ -4,11 +4,10 @@
 use defmt::*;
 use embassy_executor::Spawner;
 use py32_hal::uid;
-use py32_hal::time::Hertz;
 use {defmt_rtt as _, panic_probe as _};
 
-const ADDRESS: u8 = 0x42;
-const WRITE_DATA: [u8; 2] = [0xC2, 0x10];
+// The datasheet (seems to) specify a 128-bit UID, while the SDK uses 96-bit.
+// We read the full 128 bits to be ensure uniqueness.
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) {

--- a/examples/py32f030/src/bin/uid.rs
+++ b/examples/py32f030/src/bin/uid.rs
@@ -1,0 +1,18 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use py32_hal::uid;
+use py32_hal::time::Hertz;
+use {defmt_rtt as _, panic_probe as _};
+
+const ADDRESS: u8 = 0x42;
+const WRITE_DATA: [u8; 2] = [0xC2, 0x10];
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    info!("Hello world!");
+    let p = py32_hal::init(Default::default());
+    info!("UID: {}", uid::uid());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod i2c;
 pub mod rcc;
 pub mod timer;
 pub mod usart;
+pub mod uid;
 
 #[cfg(any(feature = "embassy-usb-driver-impl", feature = "usb-device-impl"))]
 pub mod usb;

--- a/src/uid.rs
+++ b/src/uid.rs
@@ -5,8 +5,9 @@
 // Special thanks to the Embassy Project and its contributors for their work!
 
 /// Get this device's unique 128-bit ID.
+/// The datasheet (seems to) specify a 128-bit UID, while the SDK uses 96-bit.
+/// We read the full 128 bits to ensure uniqueness.
 /// Note that the last 4 bytes of the ID consist of unknown "internal coding" and fixed values.
-/// Only the first 96 bits have known or otherwise documented structure.
 pub fn uid() -> [u8; 16] {
     unsafe { *crate::pac::UID.uid(0).as_ptr().cast::<[u8; 16]>() }
 }

--- a/src/uid.rs
+++ b/src/uid.rs
@@ -1,0 +1,35 @@
+//! Unique ID (UID)
+
+// The following code is modified from embassy-stm32
+// https://github.com/embassy-rs/embassy/tree/main/embassy-stm32
+// Special thanks to the Embassy Project and its contributors for their work!
+
+/// Get this device's unique 128-bit ID.
+pub fn uid() -> [u8; 16] {
+    unsafe { *crate::pac::UID.uid(0).as_ptr().cast::<[u8; 16]>() }
+}
+
+/// Get this device's unique 128-bit ID, encoded into a string of 32 hexadecimal ASCII digits.
+pub fn uid_hex() -> &'static str {
+    unsafe { core::str::from_utf8_unchecked(uid_hex_bytes()) }
+}
+
+/// Get this device's unique 128-bit ID, encoded into 32 hexadecimal ASCII bytes.
+pub fn uid_hex_bytes() -> &'static [u8; 32] {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    static mut UID_HEX: [u8; 32] = [0; 32];
+    static mut LOADED: bool = false;
+    critical_section::with(|_| unsafe {
+        if !LOADED {
+            let uid = uid();
+            for (idx, v) in uid.iter().enumerate() {
+                let lo = v & 0x0f;
+                let hi = (v & 0xf0) >> 4;
+                UID_HEX[idx * 2] = HEX[hi as usize];
+                UID_HEX[idx * 2 + 1] = HEX[lo as usize];
+            }
+            LOADED = true;
+        }
+    });
+    unsafe { &*core::ptr::addr_of!(UID_HEX) }
+}

--- a/src/uid.rs
+++ b/src/uid.rs
@@ -5,16 +5,18 @@
 // Special thanks to the Embassy Project and its contributors for their work!
 
 /// Get this device's unique 128-bit ID.
+/// Note that the last 4 bytes of the ID consist of unknown "internal coding" and fixed values.
+/// Only the first 96 bits have known or otherwise documented structure.
 pub fn uid() -> [u8; 16] {
     unsafe { *crate::pac::UID.uid(0).as_ptr().cast::<[u8; 16]>() }
 }
 
-/// Get this device's unique 128-bit ID, encoded into a string of 32 hexadecimal ASCII digits.
+/// Get this device's unique 128-bit ID, encoded into a string of 32 hexadecimal ASCII digits. See documentation for `uid` for caveats.
 pub fn uid_hex() -> &'static str {
     unsafe { core::str::from_utf8_unchecked(uid_hex_bytes()) }
 }
 
-/// Get this device's unique 128-bit ID, encoded into 32 hexadecimal ASCII bytes.
+/// Get this device's unique 128-bit ID, encoded into 32 hexadecimal ASCII bytes. See documentation about `uid` for caveats.
 pub fn uid_hex_bytes() -> &'static [u8; 32] {
     const HEX: &[u8; 16] = b"0123456789ABCDEF";
     static mut UID_HEX: [u8; 32] = [0; 32];


### PR DESCRIPTION
Based on the discussion in #41, depends on the data/metapac changes introduced by https://github.com/py32-rs/py32-data/pull/28. Checked in hardware on a PY32F030.