### PR TITLE
Reset interrupts on startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,10 +82,22 @@ proptest-state-machine = "0.3.0"
 
 
 [features]
-default = ["rt", "memory-x", "defmt", "time", "exti"]
+default = [
+    "rt",
+    "memory-x",
+    "defmt",
+    "time",
+    "exti",
+    "interrupts-reset-on-startup",
+]
 
 # --- Core ---
-rt = ["py32-metapac/rt"]
+rt = [
+    "py32-metapac/rt",
+    "cortex-m-rt/set-sp",
+    "cortex-m-rt/set-vtor",
+]
+interrupts-reset-on-startup = []
 memory-x = ["py32-metapac/memory-x"]
 
 # --- Debug / logging ---

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,33 @@
 mod fmt;
 include!(concat!(env!("OUT_DIR"), "/_macros.rs"));
 
+// A bootloader can jump to the app with inherited NVIC/SysTick state, unlike a hardware reset.
+#[cfg(feature = "interrupts-reset-on-startup")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __pre_init() {
+    use cortex_m::peripheral::{NVIC, SCB, SYST};
+
+    unsafe {
+        let systick = &*SYST::PTR;
+        systick.csr.write(0);
+        systick.rvr.write(0);
+        systick.cvr.write(0);
+
+        let nvic = &*NVIC::PTR;
+        nvic.icer[0].write(u32::MAX);
+        nvic.icpr[0].write(u32::MAX);
+        for priority in &nvic.ipr {
+            priority.write(0);
+        }
+    }
+
+    SCB::clear_pendsv();
+    SCB::clear_pendst();
+
+    cortex_m::asm::dsb();
+    cortex_m::asm::isb();
+}
+
 mod macros;
 #[cfg(dma)]
 use embassy_hal_internal::interrupt::Priority;


### PR DESCRIPTION
This makes booting right after exiting the HID bootloader work. I don't it can be merged in this state since there's a few questions we need to figure out:

- There are still a few instructions between setting the vtor and __pre_init, if an interrupt happens there code may execute before bss and ram is initialized.
- Should it be written in asm instead to make it faster?
- `interrupts-reset-on-startup` probably a bit long?
- Should this be enabled for all microcontrollers even those without a bootloader? Does the serial bootloader need this reset?