### PR TITLE
Add ADC mode typestate for PY32F072

### DIFF
--- a/examples/py32f072/src/bin/usb_adc_async.rs
+++ b/examples/py32f072/src/bin/usb_adc_async.rs
@@ -7,11 +7,12 @@ use defmt::*;
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
 use embassy_time::Timer;
+use embassy_usb::UsbDevice;
 use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
 use embassy_usb::driver::EndpointError;
-use embassy_usb::UsbDevice;
 use heapless::String;
 use py32_hal::adc::{Adc, SampleTime};
+use py32_hal::mode::Async;
 use py32_hal::peripherals::{ADC1, USB};
 use py32_hal::rcc::{HsiFs, Pll, PllMul, PllSource, Sysclk};
 use py32_hal::usb::{Driver, InterruptHandler as UsbInterruptHandler};
@@ -96,7 +97,7 @@ async fn usb_task(mut usb: MyUsbDevice) -> ! {
 }
 
 async fn adc_task(
-    mut adc: Adc<'static, ADC1>,
+    mut adc: Adc<'static, ADC1, Async>,
     mut pin: impl py32_hal::adc::AdcChannel<ADC1>,
     mut vrefint: adc::VrefInt,
     mut class: MyUsbClass,
@@ -126,7 +127,7 @@ impl From<EndpointError> for Disconnected {
 }
 
 async fn sample_and_write(
-    adc: &mut Adc<'static, ADC1>,
+    adc: &mut Adc<'static, ADC1, Async>,
     pin: &mut impl py32_hal::adc::AdcChannel<ADC1>,
     vrefint: &mut adc::VrefInt,
     class: &mut MyUsbClass,

--- a/src/adc/mod.rs
+++ b/src/adc/mod.rs
@@ -18,6 +18,8 @@ pub use _version::*;
 use core::marker::PhantomData;
 use embassy_sync::waitqueue::AtomicWaker;
 
+#[cfg(adc_v2)]
+use crate::mode::{Blocking, Mode};
 pub use crate::pac::adc::vals;
 pub use crate::pac::adc::vals::Res as Resolution;
 pub use crate::pac::adc::vals::SampleTime;
@@ -27,10 +29,20 @@ use crate::peripherals;
 dma_trait!(RxDma, Instance);
 
 /// Analog to Digital driver.
+#[cfg(any(adc_v1, adc_v1b))]
 pub struct Adc<'d, T: Instance> {
     #[allow(unused)]
     adc: crate::Peri<'d, T>,
     sample_time: SampleTime,
+}
+
+/// Analog to Digital driver.
+#[cfg(adc_v2)]
+pub struct Adc<'d, T: Instance, M: Mode = Blocking> {
+    #[allow(unused)]
+    adc: crate::Peri<'d, T>,
+    sample_time: SampleTime,
+    _mode: PhantomData<M>,
 }
 
 pub struct State {

--- a/src/adc/ringbuffered_v2.rs
+++ b/src/adc/ringbuffered_v2.rs
@@ -4,13 +4,14 @@
 
 use core::marker::PhantomData;
 use core::mem;
-use core::sync::atomic::{compiler_fence, Ordering};
+use core::sync::atomic::{Ordering, compiler_fence};
 
 use embassy_hal_internal::Peri;
 use py32_metapac::adc::vals::SampleTime;
 
 use crate::adc::{Adc, AdcChannel, Instance, RxDma};
 use crate::dma::{Priority, ReadableRingBuffer, TransferOptions};
+use crate::mode::Blocking;
 use crate::rcc;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -95,7 +96,7 @@ pub struct RingBufferedAdc<'d, T: Instance> {
     ring_buf: ReadableRingBuffer<'d, u16>,
 }
 
-impl<'d, T: Instance> Adc<'d, T> {
+impl<'d, T: Instance> Adc<'d, T, Blocking> {
     /// Configures the ADC to use a DMA ring buffer for continuous data acquisition.
     ///
     /// The `dma_buf` should be large enough to prevent DMA buffer overrun.
@@ -194,8 +195,7 @@ impl<'d, T: Instance> RingBufferedAdc<'d, T> {
                 let new_l: Sequence = sequence;
                 trace!(
                     "Setting sequence length from {:?} to {:?}",
-                    prev as u8,
-                    new_l as u8
+                    prev as u8, new_l as u8
                 );
                 r.set_l(sequence.into())
             } else {

--- a/src/adc/v2.rs
+++ b/src/adc/v2.rs
@@ -11,8 +11,9 @@ use crate::Peri;
 use super::blocking_delay_us;
 use crate::adc::{Adc, AdcChannel, Instance, Resolution, SampleTime};
 use crate::interrupt::typelevel::Interrupt;
-use crate::pac::adc::vals::Extsel;
+use crate::mode::{Async, Blocking, Mode};
 use crate::pac::RCC;
+use crate::pac::adc::vals::Extsel;
 use crate::peripherals::ADC1;
 use crate::time::Hertz;
 use crate::{interrupt, rcc};
@@ -113,7 +114,7 @@ impl Prescaler {
     }
 }
 
-impl<'d, T> Adc<'d, T>
+impl<'d, T> Adc<'d, T, Blocking>
 where
     T: Instance,
 {
@@ -122,6 +123,54 @@ where
         Self::new_with_prediv(adc, presc)
     }
 
+    /// adc_div: The PCLK division factor
+    pub fn new_with_prediv(adc: Peri<'d, T>, adc_div: Prescaler) -> Self {
+        Self::new_inner(adc, adc_div)
+    }
+
+    /// Perform a single conversion.
+    fn convert(&mut self) -> u16 {
+        // clear end of conversion flag
+        T::regs().sr().modify(|reg| {
+            reg.set_eoc(false);
+        });
+
+        // Start conversion
+        T::regs().cr2().modify(|reg| {
+            reg.set_swstart(true);
+            reg.set_exttrig(true);
+        });
+
+        while T::regs().sr().read().strt() == false {
+            // spin //wait for actual start
+        }
+        while T::regs().sr().read().eoc() == false {
+            // spin //wait for finish
+        }
+
+        T::regs().dr().read().0 as u16
+    }
+
+    pub fn blocking_read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
+        channel.setup();
+
+        // Configure ADC
+        let channel = channel.channel();
+
+        // Select channel
+        T::regs().sqr3().write(|reg| reg.set_sq(0, channel));
+
+        // Configure channel
+        Self::set_channel_sample_time(channel, self.sample_time);
+
+        self.convert()
+    }
+}
+
+impl<'d, T> Adc<'d, T, Async>
+where
+    T: Instance,
+{
     pub fn new_async(
         adc: Peri<'d, T>,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
@@ -131,7 +180,69 @@ where
     }
 
     /// adc_div: The PCLK division factor
-    pub fn new_with_prediv(adc: Peri<'d, T>, adc_div: Prescaler) -> Self {
+    pub fn new_with_prediv_async(
+        adc: Peri<'d, T>,
+        adc_div: Prescaler,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Self {
+        let adc = Self::new_inner(adc, adc_div);
+
+        T::Interrupt::unpend();
+        unsafe {
+            T::Interrupt::enable();
+        }
+
+        adc
+    }
+
+    async fn convert_async(&mut self) -> u16 {
+        T::regs().sr().modify(|reg| {
+            reg.set_eoc(false);
+        });
+
+        T::regs().cr1().modify(|reg| reg.set_eocie(true));
+
+        T::regs().cr2().modify(|reg| {
+            reg.set_swstart(true);
+            reg.set_exttrig(true);
+        });
+
+        poll_fn(|cx| {
+            T::state().waker.register(cx.waker());
+
+            if T::regs().sr().read().eoc() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        })
+        .await;
+
+        T::regs().dr().read().0 as u16
+    }
+
+    pub async fn read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
+        channel.setup();
+
+        let channel = channel.channel();
+
+        // Select a single-channel regular sequence.
+        T::regs().sqr1().modify(|reg| reg.set_l(0));
+        T::regs().sqr3().write(|reg| reg.set_sq(0, channel));
+
+        // Configure channel
+        Self::set_channel_sample_time(channel, self.sample_time);
+
+        self.convert_async().await
+    }
+}
+
+impl<'d, T, M> Adc<'d, T, M>
+where
+    T: Instance,
+    M: Mode,
+{
+    fn new_inner(adc: Peri<'d, T>, adc_div: Prescaler) -> Self {
         rcc::enable_and_reset::<T>();
 
         RCC.cr().modify(|reg| {
@@ -152,23 +263,8 @@ where
         Self {
             adc,
             sample_time: SampleTime::from_bits(0),
+            _mode: PhantomData,
         }
-    }
-
-    /// adc_div: The PCLK division factor
-    pub fn new_with_prediv_async(
-        adc: Peri<'d, T>,
-        adc_div: Prescaler,
-        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
-    ) -> Self {
-        let adc = Self::new_with_prediv(adc, adc_div);
-
-        T::Interrupt::unpend();
-        unsafe {
-            T::Interrupt::enable();
-        }
-
-        adc
     }
 
     pub fn set_sample_time(&mut self, sample_time: SampleTime) {
@@ -211,85 +307,6 @@ where
 
     //     Vbat {}
     // }
-
-    /// Perform a single conversion.
-    fn convert(&mut self) -> u16 {
-        // clear end of conversion flag
-        T::regs().sr().modify(|reg| {
-            reg.set_eoc(false);
-        });
-
-        // Start conversion
-        T::regs().cr2().modify(|reg| {
-            reg.set_swstart(true);
-            reg.set_exttrig(true);
-        });
-
-        while T::regs().sr().read().strt() == false {
-            // spin //wait for actual start
-        }
-        while T::regs().sr().read().eoc() == false {
-            // spin //wait for finish
-        }
-
-        T::regs().dr().read().0 as u16
-    }
-
-    async fn convert_async(&mut self) -> u16 {
-        T::regs().sr().modify(|reg| {
-            reg.set_eoc(false);
-        });
-
-        T::regs().cr1().modify(|reg| reg.set_eocie(true));
-
-        T::regs().cr2().modify(|reg| {
-            reg.set_swstart(true);
-            reg.set_exttrig(true);
-        });
-
-        poll_fn(|cx| {
-            T::state().waker.register(cx.waker());
-
-            if T::regs().sr().read().eoc() {
-                Poll::Ready(())
-            } else {
-                Poll::Pending
-            }
-        })
-        .await;
-
-        T::regs().dr().read().0 as u16
-    }
-
-    pub fn blocking_read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
-        channel.setup();
-
-        // Configure ADC
-        let channel = channel.channel();
-
-        // Select channel
-        T::regs().sqr3().write(|reg| reg.set_sq(0, channel));
-
-        // Configure channel
-        Self::set_channel_sample_time(channel, self.sample_time);
-
-        self.convert()
-    }
-
-    pub async fn read(&mut self, channel: &mut impl AdcChannel<T>) -> u16 {
-        channel.setup();
-
-        let channel = channel.channel();
-
-        // Select a single-channel regular sequence.
-        T::regs().sqr1().modify(|reg| reg.set_l(0));
-        T::regs().sqr3().write(|reg| reg.set_sq(0, channel));
-
-        // Configure channel
-        Self::set_channel_sample_time(channel, self.sample_time);
-
-        self.convert_async().await
-    }
 
     fn set_channel_sample_time(ch: u8, sample_time: SampleTime) {
         let sample_time = sample_time.into();
@@ -348,7 +365,7 @@ where
     }
 }
 
-impl<'d, T: Instance> Drop for Adc<'d, T> {
+impl<'d, T: Instance, M: Mode> Drop for Adc<'d, T, M> {
     fn drop(&mut self) {
         T::regs().cr2().modify(|reg| {
             reg.set_adon(false);


### PR DESCRIPTION
this makes it typesafe. previous the code you can init a blocking adc and use the async fn, this should be blocked now