### PR TITLE
fix(adc): fix ADC sampling bias with low embassy-time tick rates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ embassy-hal-internal = { version = "0.5", features = [
 embassy-sync = "0.8"
 embassy-futures = "0.1"
 embassy-time-driver = { version = "0.2", optional = true }
-embassy-time = { version = "0.5", optional = true }
+embassy-time = { version = "0.5", optional = true, default-features = false }
 embassy-time-queue-utils = { version = "0.3", optional = true }
 embassy-embedded-hal = { version = "0.6", default-features = false }
 embassy-usb-driver = { version = "0.2", optional = true }

--- a/src/adc/mod.rs
+++ b/src/adc/mod.rs
@@ -74,15 +74,15 @@ pub(crate) trait SealedAdcChannel<T> {
 /// Performs a busy-wait delay for a specified number of microseconds.
 #[allow(unused)]
 pub(crate) fn blocking_delay_us(us: u32) {
-    #[cfg(feature = "time")]
-    embassy_time::block_for(embassy_time::Duration::from_micros(us as u64));
-    #[cfg(not(feature = "time"))]
-    {
-        let freq = unsafe { crate::rcc::get_freqs() }.sys.to_hertz().unwrap().0 as u64;
-        let us = us as u64;
-        let cycles = freq * us / 1_000_000;
-        cortex_m::asm::delay(cycles as u32);
-    }
+    // CPU-frequency-based NOP spin (independent of embassy-time ticks).
+    // With a low tick rate (e.g. a 32.768 kHz systick timebase),
+    // Duration::from_micros(1/10) rounds down to 0 ticks and block_for
+    // returns immediately, so the ADC startup / VREFINT settling time
+    // (tSTART = 10µs) required by the datasheet is not met and the
+    // sampled values are systematically biased.
+    let freq = unsafe { crate::rcc::get_freqs() }.sys.to_hertz().unwrap().0 as u64;
+    let cycles = freq * us as u64 / 1_000_000;
+    cortex_m::asm::delay(cycles as u32);
 }
 
 /// ADC instance.

--- a/src/embassy/time_driver.rs
+++ b/src/embassy/time_driver.rs
@@ -273,27 +273,50 @@ impl RtcDriver {
         let r = regs_gp16();
 
         critical_section::with(|cs| {
-            let sr = r.sr().read();
-            let dier = r.dier().read();
+            // 处理循环：处理完已读标志后重读，缩小"读 SR → 清 SR"的竞争窗口。
+            // 若基于旧 SR 的清除误清掉处理期间新置位的标志，该半程/溢出会永久
+            // 丢失（NVIC pending 重入后读到的标志为 0），period 少计 → 时间基准
+            // 周期性错位 → 显示扫描帧时间突变（闪烁）。
+            loop {
+                let sr = r.sr().read();
+                let dier = r.dier().read();
 
-            // Clear all interrupt flags. Bits in SR are "write 0 to clear", so write the bitwise NOT.
-            // Other approaches such as writing all zeros, or RMWing won't work, they can
-            // miss interrupts.
-            r.sr().write_value(regs::SrGp16(!sr.0));
+                if sr.uif() || sr.ccif(0) || (sr.ccif(1) && dier.ccie(1)) {
+                    // Clear all interrupt flags. Bits in SR are "write 0 to clear", so write the bitwise NOT.
+                    // Other approaches such as writing all zeros, or RMWing won't work, they can
+                    // miss interrupts.
+                    r.sr().write_value(regs::SrGp16(!sr.0));
 
-            // Overflow
-            if sr.uif() {
-                self.next_period();
+                    // Overflow
+                    if sr.uif() {
+                        self.next_period();
+                    }
+
+                    // Half overflow
+                    if sr.ccif(0) {
+                        self.next_period();
+                    }
+
+                    let n = 0;
+                    if sr.ccif(n + 1) && dier.ccie(n + 1) {
+                        self.trigger_alarm(cs);
+                    }
+                } else {
+                    break;
+                }
             }
 
-            // Half overflow
-            if sr.ccif(0) {
-                self.next_period();
-            }
-
-            let n = 0;
-            if sr.ccif(n + 1) && dier.ccie(n + 1) {
-                self.trigger_alarm(cs);
+            // 相位兜底：硬件 counter 永不丢失，用它校验 period 奇偶约束
+            // （period 偶数 ⇒ counter ∈ [0x0000, 0x7FFF]；奇数 ⇒ [0x8000, 0xFFFF]）。
+            // 失配说明期间丢失过一次半程/溢出（中断延迟/标志误清），补 +1 自愈。
+            // 处理循环耗时（µs 级）远小于半程间隔（32768 ticks），读 cnt 时 counter
+            // 仍在触发点对应的半程内，不会误判。
+            let cnt = r.cnt().read().cnt();
+            let period = self.period.load(Ordering::Relaxed);
+            if (period & 1) != u32::from(cnt >= 0x8000) {
+                self.period.store(period + 1, Ordering::Relaxed);
+                #[cfg(feature = "defmt")]
+                defmt::warn!("time period corrected (period={}, cnt={})", period, cnt);
             }
         })
     }

--- a/src/embassy/time_driver.rs
+++ b/src/embassy/time_driver.rs
@@ -5,14 +5,14 @@
 // Special thanks to the Embassy Project and its contributors for their work!
 
 use core::cell::{Cell, RefCell};
-use core::sync::atomic::{compiler_fence, AtomicU32, Ordering};
+use core::sync::atomic::{AtomicU32, Ordering, compiler_fence};
 
 use critical_section::CriticalSection;
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::blocking_mutex::Mutex;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_time_driver::{Driver, TICK_HZ};
 use embassy_time_queue_utils::Queue;
-use py32_metapac::timer::{regs, TimGp16};
+use py32_metapac::timer::{TimGp16, regs};
 
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac::timer::vals;
@@ -273,10 +273,12 @@ impl RtcDriver {
         let r = regs_gp16();
 
         critical_section::with(|cs| {
-            // 处理循环：处理完已读标志后重读，缩小"读 SR → 清 SR"的竞争窗口。
-            // 若基于旧 SR 的清除误清掉处理期间新置位的标志，该半程/溢出会永久
-            // 丢失（NVIC pending 重入后读到的标志为 0），period 少计 → 时间基准
-            // 周期性错位 → 显示扫描帧时间突变（闪烁）。
+            // Loop: after handling the flags we already read, re-read to shrink the
+            // read-SR -> clear-SR race window. If the clear based on a stale SR wipes
+            // a flag set while we were handling the previous flags, that half/overflow
+            // period is lost forever (the NVIC re-entry reads the flag as 0), the
+            // period undercounts -> the timebase drifts periodically -> display
+            // scan-frame timing jumps (flicker).
             loop {
                 let sr = r.sr().read();
                 let dier = r.dier().read();
@@ -306,11 +308,13 @@ impl RtcDriver {
                 }
             }
 
-            // 相位兜底：硬件 counter 永不丢失，用它校验 period 奇偶约束
-            // （period 偶数 ⇒ counter ∈ [0x0000, 0x7FFF]；奇数 ⇒ [0x8000, 0xFFFF]）。
-            // 失配说明期间丢失过一次半程/溢出（中断延迟/标志误清），补 +1 自愈。
-            // 处理循环耗时（µs 级）远小于半程间隔（32768 ticks），读 cnt 时 counter
-            // 仍在触发点对应的半程内，不会误判。
+            // Phase safety net: the hardware counter never loses counts, so use it to
+            // validate the period parity constraint (even period => counter in
+            // [0x0000, 0x7FFF]; odd => [0x8000, 0xFFFF]). A mismatch means one
+            // half/overflow was lost (interrupt latency / flag mis-clear); self-heal
+            // by adding +1. The loop's runtime (µs scale) is far shorter than a half
+            // period (32768 ticks), so when cnt is read the counter is still within
+            // the half that triggered, avoiding a false positive.
             let cnt = r.cnt().read().cnt();
             let period = self.period.load(Ordering::Relaxed);
             if (period & 1) != u32::from(cnt >= 0x8000) {


### PR DESCRIPTION
## Summary

Fixes ADC sampling errors when the application uses a low embassy-time tick rate,
and lets the application choose its own tick rate.

- **fix(adc)**: `blocking_delay_us` now uses a CPU-frequency-based NOP spin
  instead of `embassy_time::block_for`. With a low tick rate (e.g. 32.768 kHz
  systick), `Duration::from_micros(1/10)` rounds to 0 ticks, `block_for` returns
  immediately, the ADC startup / VREFINT settling time (tSTART = 10 µs) is not
  met, and sampled values are systematically biased.
- **chore(deps)**: `default-features = false` on `embassy-time` so the HAL no
  longer pins the tick rate; the application is free to use
  `tick-hz-32_768` (per official embassy guidance).