### PR TITLE
Add CRC driver

### DIFF
--- a/examples/py32f072/src/bin/crc.rs
+++ b/examples/py32f072/src/bin/crc.rs
@@ -1,0 +1,37 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use py32_hal::crc::Crc;
+use {defmt_rtt as _, panic_probe as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = py32_hal::init(Default::default());
+
+    info!("Hello World!");
+
+    let mut crc = Crc::new(p.CRC);
+
+    // CRC-32 (poly 0x4C11DB7, init 0xFFFF_FFFF, no reflection).
+    // Words are fed MSB-first, i.e. a word stream is equivalent to the
+    // big-endian byte stream "12345678".
+    crc.feed_words(&[0x31323334, 0x35363738]);
+    let result = crc.read();
+    info!("crc(\"12345678\") = {:#010x}", result);
+    if result != 0x49e3_c2fb {
+        defmt::panic!("crc mismatch");
+    }
+
+    // Feed one more word after a reset.
+    crc.reset();
+    crc.feed_word(0x41424344); // "ABCD", MSB-first like the vector above
+    let result = crc.read();
+    info!("crc(\"ABCD\") = {:#010x}", result);
+    if result != 0xabcf_9a63 {
+        defmt::panic!("crc mismatch");
+    }
+
+    info!("Test success");
+}

--- a/src/crc.rs
+++ b/src/crc.rs
@@ -1,0 +1,57 @@
+//! CRC (Cyclic Redundancy Check) calculation unit
+
+// The following code is modified from embassy-stm32
+// https://github.com/embassy-rs/embassy/tree/main/embassy-stm32
+// Special thanks to the Embassy Project and its contributors for their work!
+
+use crate::peripherals::CRC;
+use crate::{Peri, rcc};
+
+/// CRC driver.
+///
+/// The peripheral computes a CRC-32 (polynomial 0x4C11DB7, init 0xFFFF_FFFF,
+/// no input/output reversal) over 32-bit words fed MSB-first, taking 4 AHB
+/// clock cycles per word.
+pub struct Crc<'d> {
+    _peri: Peri<'d, CRC>,
+}
+
+impl<'d> Crc<'d> {
+    /// Instantiates the CRC peripheral and initializes it to default values.
+    pub fn new(peripheral: Peri<'d, CRC>) -> Self {
+        // Note: enable and reset come from RccPeripheral.
+        // enable CRC clock in RCC.
+        rcc::enable_and_reset::<CRC>();
+        let mut instance = Self { _peri: peripheral };
+        instance.reset();
+        instance
+    }
+
+    /// Resets the CRC unit to default value (0xFFFF_FFFF)
+    pub fn reset(&mut self) {
+        crate::pac::CRC.cr().write(|w| w.set_reset(true));
+    }
+
+    /// Feeds a word into the CRC peripheral.
+    pub fn feed_word(&mut self, word: u32) {
+        crate::pac::CRC.dr().write_value(word);
+    }
+
+    /// Feeds a slice of words into the CRC peripheral.
+    pub fn feed_words(&mut self, words: &[u32]) {
+        for word in words {
+            crate::pac::CRC.dr().write_value(*word);
+        }
+    }
+
+    /// Read the CRC result value.
+    pub fn read(&self) -> u32 {
+        crate::pac::CRC.dr().read()
+    }
+}
+
+impl<'d> Drop for Crc<'d> {
+    fn drop(&mut self) {
+        rcc::disable::<CRC>();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@ pub mod mode {
 }
 
 pub mod adc;
+#[cfg(crc)]
+pub mod crc;
 #[cfg(dac)]
 pub mod dac;
 #[cfg(dma)]


### PR DESCRIPTION
this is a little bit different from stm32's crc_v1.rs. The structure is like crc_v1.rs, but feed_word doesn't read and return a u32, which is more similar to crc_v2v3.rs. Might be better for performance since .read() could be a volatile read and never optimized away by the compiler?