### PR TITLE
Add LSI/LSE config so the LPTIM kernel-clock mux resolves

### DIFF
--- a/examples/py32f072/src/bin/blinky_lsi.rs
+++ b/examples/py32f072/src/bin/blinky_lsi.rs
@@ -1,0 +1,31 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use py32_hal::gpio::{Level, Output, Speed};
+use py32_hal::rcc::{LsConfig, Sysclk};
+use {defmt_rtt as _, panic_halt as _};
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut cfg: py32_hal::Config = Default::default();
+    cfg.rcc.ls = LsConfig::default_lsi();
+    cfg.rcc.sys = Sysclk::LSI;
+    let p = py32_hal::init(cfg);
+
+    info!("Hello World!");
+
+    let mut led = Output::new(p.PB2, Level::High, Speed::Low);
+
+    loop {
+        info!("high");
+        led.set_high();
+        Timer::after_millis(1000).await;
+
+        info!("low");
+        led.set_low();
+        Timer::after_millis(1000).await;
+    }
+}

--- a/src/rcc/f0.rs
+++ b/src/rcc/f0.rs
@@ -200,11 +200,15 @@ pub(crate) unsafe fn init(config: Config) { unsafe {
     //     Hertz(48_000_000)
     // });
 
+    let (lsi, lse) = config.ls.init();
+
     // Configure sysclk
     let sys = match config.sys {
         Sysclk::HSI => unwrap!(hsi_value) / config.hsidiv,
         Sysclk::HSE => unwrap!(hse),
         Sysclk::PLL => unwrap!(pll),
+        Sysclk::LSI => unwrap!(lsi.to_hertz()),
+        Sysclk::LSE => unwrap!(lse.to_hertz()),
         _ => unreachable!(),
     };
 
@@ -265,8 +269,6 @@ pub(crate) unsafe fn init(config: Config) { unsafe {
         }
     };
      */
-
-    let (lsi, lse) = config.ls.init();
 
     config.mux.init();
 

--- a/src/rcc/f0.rs
+++ b/src/rcc/f0.rs
@@ -77,7 +77,8 @@ pub struct Config {
     pub apb1_pre: APBPrescaler,
     /// Per-peripheral kernel clock selection muxes
     pub mux: super::mux::ClockMux,
-    // pub ls: super::LsConfig,
+    /// Low-speed oscillator (LSI/LSE) configuration
+    pub ls: super::LsConfig,
 }
 
 impl Default for Config {
@@ -90,7 +91,7 @@ impl Default for Config {
             pll: None,
             ahb_pre: AHBPrescaler::DIV1,
             apb1_pre: APBPrescaler::DIV1,
-            // ls: Default::default(),
+            ls: Default::default(),
             mux: Default::default(),
         }
     }
@@ -245,7 +246,6 @@ pub(crate) unsafe fn init(config: Config) { unsafe {
         RCC.cr().modify(|w| w.set_hsion(false));
     }
 
-    // let rtc = config.ls.init();
 
     /*
     TODO: Maybe add something like this to clock_mux? How can we autogenerate the data for this?
@@ -265,6 +265,8 @@ pub(crate) unsafe fn init(config: Config) { unsafe {
         }
     };
      */
+
+    let (lsi, lse) = config.ls.init();
 
     config.mux.init();
 
@@ -287,7 +289,8 @@ pub(crate) unsafe fn init(config: Config) { unsafe {
         pclk1_tim: Some(pclk1_tim).into(),
         sys: Some(sys).into(),
         hsi: hsi_value.into(),
-        lse: None.into(),
+        lsi,
+        lse,
         pll: pll.into(),
     };
     crate::rcc::set_freqs(clocks);

--- a/src/rcc/f002b.rs
+++ b/src/rcc/f002b.rs
@@ -87,10 +87,14 @@ pub(crate) unsafe fn init(config: Config) {
         }
     };
 
+    let (lsi, lse) = config.ls.init();
+
     // Configure sysclk
     let sys = match config.sys {
         Sysclk::HSI => unwrap!(hsi_value) / config.hsidiv,
         Sysclk::HSE => unwrap!(hse),
+        Sysclk::LSI => unwrap!(lsi.to_hertz()),
+        Sysclk::LSE => unwrap!(lse.to_hertz()),
         _ => unreachable!(),
     };
 
@@ -123,8 +127,6 @@ pub(crate) unsafe fn init(config: Config) {
     if hsi == None {
         RCC.cr().modify(|w| w.set_hsion(false));
     }
-
-    let (lsi, lse) = config.ls.init();
 
     config.mux.init();
 

--- a/src/rcc/f002b.rs
+++ b/src/rcc/f002b.rs
@@ -24,7 +24,8 @@ pub struct Config {
     pub apb1_pre: APBPrescaler,
     /// Per-peripheral kernel clock selection muxes
     pub mux: super::mux::ClockMux,
-    // pub ls: super::LsConfig,
+    /// Low-speed oscillator (LSI/LSE) configuration
+    pub ls: super::LsConfig,
 }
 
 impl Default for Config {
@@ -36,7 +37,7 @@ impl Default for Config {
             hsidiv: Hsidiv::DIV1,
             ahb_pre: AHBPrescaler::DIV1,
             apb1_pre: APBPrescaler::DIV1,
-            // ls: Default::default(),
+            ls: Default::default(),
             mux: Default::default(),
         }
     }
@@ -123,7 +124,7 @@ pub(crate) unsafe fn init(config: Config) {
         RCC.cr().modify(|w| w.set_hsion(false));
     }
 
-    // let rtc = config.ls.init();
+    let (lsi, lse) = config.ls.init();
 
     config.mux.init();
 
@@ -133,7 +134,8 @@ pub(crate) unsafe fn init(config: Config) {
         pclk1_tim: Some(pclk1_tim).into(),
         sys: Some(sys).into(),
         hsi: hsi_value.into(),
-        lse: None.into(),
+        lsi,
+        lse,
     };
     crate::rcc::set_freqs(clocks);
 }

--- a/src/rcc/mod.rs
+++ b/src/rcc/mod.rs
@@ -31,12 +31,105 @@ pub struct Clocks {
     pub sys: crate::time::MaybeHertz,
 
     pub hsi: crate::time::MaybeHertz,
+    pub lsi: crate::time::MaybeHertz,
     pub lse: crate::time::MaybeHertz,
     #[cfg(not(rcc_f002b))]
     pub pll: crate::time::MaybeHertz,
     // pub rtc: crate::time::MaybeHertz,
     // pub sys: Option<crate::time::Hertz>,
     // pub usb: Option<crate::time::Hertz>,
+}
+
+pub const LSI_FREQ: crate::time::Hertz = crate::time::Hertz(32_768);
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum LseMode {
+    #[default]
+    Oscillator,
+    Bypass,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LseConfig {
+    pub frequency: crate::time::Hertz,
+    pub mode: LseMode,
+}
+
+impl LseConfig {
+    pub const fn new() -> Self {
+        Self {
+            frequency: crate::time::Hertz(32_768),
+            mode: LseMode::Oscillator,
+        }
+    }
+}
+
+impl Default for LseConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LsConfig {
+    pub lsi: bool,
+    pub lse: Option<LseConfig>,
+}
+
+impl LsConfig {
+    pub const fn default_lsi() -> Self {
+        Self { lsi: true, lse: None }
+    }
+
+    pub const fn default_lse() -> Self {
+        Self {
+            lsi: false,
+            lse: Some(LseConfig::new()),
+        }
+    }
+
+    pub const fn off() -> Self {
+        Self { lsi: false, lse: None }
+    }
+
+    pub(crate) fn init(&self) -> (crate::time::MaybeHertz, crate::time::MaybeHertz) {
+        use crate::pac::RCC;
+
+        // ~100 ms of spinning at the highest supported core clock.
+        const READY_TIMEOUT: u32 = 5_000_000;
+
+        fn wait(mut ready: impl FnMut() -> bool, name: &str) {
+            for _ in 0..READY_TIMEOUT {
+                if ready() {
+                    return;
+                }
+            }
+            panic!("{} did not become ready", name);
+        }
+
+        if self.lsi {
+            RCC.csr().modify(|w| w.set_lsion(true));
+            wait(|| RCC.csr().read().lsirdy(), "LSI");
+        }
+
+        let lse = self.lse.map(|cfg| {
+            // LSEBYP must be set together with (or before) LSEON.
+            RCC.bdcr().modify(|w| {
+                w.set_lsebyp(matches!(cfg.mode, LseMode::Bypass));
+                w.set_lseon(true);
+            });
+            wait(|| RCC.bdcr().read().lserdy(), "LSE");
+            cfg.frequency
+        });
+
+        (self.lsi.then_some(LSI_FREQ).into(), lse.into())
+    }
+}
+
+impl Default for LsConfig {
+    fn default() -> Self {
+        Self::off()
+    }
 }
 
 // #[cfg(feature = "low-power")]


### PR DESCRIPTION
embassy-stm32 by default turns lsi on, should we follow the pattern?